### PR TITLE
어빌리티에 쿨다운 로직 및 자동 시전 기능 추가

### DIFF
--- a/Config/DefaultGameplayTags.ini
+++ b/Config/DefaultGameplayTags.ini
@@ -10,6 +10,9 @@ InvalidTagCharacters="\"\',"
 NumBitsForContainerSize=6
 NetIndexFirstBitSegment=16
 +GameplayTagList=(Tag="Ability.Multiplier",DevComment="")
++GameplayTagList=(Tag="Ability.Skill.Attack",DevComment="")
++GameplayTagList=(Tag="Cooldown.Ability.Attack",DevComment="")
++GameplayTagList=(Tag="Data.Cooldown.Duration",DevComment="")
 +GameplayTagList=(Tag="Input.Attack",DevComment="")
 +GameplayTagList=(Tag="Stat.AttackDamage",DevComment="")
 +GameplayTagList=(Tag="Stat.AttackSpeed",DevComment="")

--- a/Content/Core/Abilities/GA_Drg_Attack.uasset
+++ b/Content/Core/Abilities/GA_Drg_Attack.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:085dc5554fb270a21b439e967f161dff02103b78a7e2bd3dcef088557be97cb3
-size 36581
+oid sha256:479be3a32946fb1f5c985395de60abc879cc1662869c7d7541d04393caa538d0
+size 42904

--- a/Content/Core/Abilities/GameplayEffects/BP_Drg_ExpUp.uasset
+++ b/Content/Core/Abilities/GameplayEffects/BP_Drg_ExpUp.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:47fde4e06d34d1315d615aa534e51a515a1b2ab6f382808ddc34830e2b2b8fbe
-size 13043

--- a/Content/Core/Abilities/GameplayEffects/Cooldown/GE_Drg_Cooldown_Base.uasset
+++ b/Content/Core/Abilities/GameplayEffects/Cooldown/GE_Drg_Cooldown_Base.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08e3f70b29a43331c06c15b8b989ba6e18b5ea0f51e35c1535474283d7501361
+size 8322

--- a/Content/Core/Abilities/GameplayEffects/GE_Drg_ExpUp.uasset
+++ b/Content/Core/Abilities/GameplayEffects/GE_Drg_ExpUp.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c75ef0b9c40cf316d6c78da18a818c0217725852cf376e179207a1b4aef29693
+size 13043

--- a/Content/Item/PickUp/BP_Drg_Pickup_XP.uasset
+++ b/Content/Item/PickUp/BP_Drg_Pickup_XP.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a8730077964e5e8bf72db0a8a467cf7af8788dc79cec2f5b09fe57d7159a897e
-size 33703
+oid sha256:ab6797116153eecbea6565d817313131c5f8143ef0864199b866a1836b724ca4
+size 33407

--- a/Source/Drg/AbilitySystem/Abilities/DrgGameplayAbility.cpp
+++ b/Source/Drg/AbilitySystem/Abilities/DrgGameplayAbility.cpp
@@ -3,3 +3,99 @@
 
 #include "DrgGameplayAbility.h"
 
+#include "AbilitySystemComponent.h"
+#include "Abilities/Tasks/AbilityTask_WaitGameplayTag.h"
+#include "Drg/AbilitySystem/Attributes/DrgAttributeSet.h"
+
+void UDrgGameplayAbility::ActivateAbility(const FGameplayAbilitySpecHandle Handle,
+                                          const FGameplayAbilityActorInfo* ActorInfo,
+                                          const FGameplayAbilityActivationInfo ActivationInfo,
+                                          const FGameplayEventData* TriggerEventData)
+{
+	Super::ActivateAbility(Handle, ActorInfo, ActivationInfo, TriggerEventData);
+
+	StartCooldown();
+}
+
+void UDrgGameplayAbility::EndTaskAutoCheck()
+{
+	bIsTaskFinished = true;
+	if (!bIsOnAutoCast)
+	{
+		EndAbility(CurrentSpecHandle, GetCurrentActorInfo(), GetCurrentActivationInfo(), true, false);
+	}
+}
+
+void UDrgGameplayAbility::StartCooldown()
+{
+	if (!ensureMsgf(BaseCooldown > 0.0f, TEXT("어빌리티 [%s]의 BaseCooldown 값은 0보다 커야 합니다. (현재 값: %f)"),
+	                *GetName(), BaseCooldown))
+	{
+		return;
+	}
+	UAbilitySystemComponent* ASC = GetAbilitySystemComponentFromActorInfo();
+	if (!ensure(ASC))
+	{
+		return;
+	}
+
+	const float AttackSpeed = ASC->GetNumericAttribute(UDrgAttributeSet::GetAttackSpeedAttribute());
+
+	const float FinalDuration = (AttackSpeed > 0.0f) ? (BaseCooldown / AttackSpeed) : BaseCooldown;
+
+	if (const UGameplayEffect* CooldownGE = GetCooldownGameplayEffect())
+	{
+		FGameplayEffectSpecHandle SpecHandle = MakeOutgoingGameplayEffectSpec(CooldownGE->GetClass());
+		if (SpecHandle.IsValid())
+		{
+			SpecHandle.Data->SetSetByCallerMagnitude(FGameplayTag::RequestGameplayTag(FName("Data.Cooldown.Duration")),
+			                                         FinalDuration);
+			FActiveGameplayEffectHandle EffectHandle = ApplyGameplayEffectSpecToOwner(
+				CurrentSpecHandle, GetCurrentActorInfo(), GetCurrentActivationInfo(), SpecHandle);
+			if (!EffectHandle.IsValid())
+			{
+				UE_LOG(LogTemp, Error, TEXT("%s: 쿨타임 적용 실패"), *GetName());
+			}
+		}
+	}
+
+	// 쿨다운 태그가 제거되면 OnCooldownEnded 실행하게 만드는 코드
+	if (bIsOnAutoCast)
+	{
+		const FGameplayTagContainer* CooldownTags = GetCooldownTags();
+		if (ensure(CooldownTags && CooldownTags->Num() > 0))
+		{
+			UAbilityTask_WaitGameplayTagRemoved* WaitCooldownTask =
+				UAbilityTask_WaitGameplayTagRemoved::WaitGameplayTagRemove(this, CooldownTags->First());
+			WaitCooldownTask->Removed.AddDynamic(this, &UDrgGameplayAbility::OnCooldownEnded);
+			WaitCooldownTask->ReadyForActivation();
+		}
+		else
+		{
+			check(false && "자동시전 활성화가 되어 있지만 쿨타임이 설정되어 있지 않음");
+		}
+	}
+}
+
+void UDrgGameplayAbility::EndAbilityAutoCheck()
+{
+	if (!bIsOnAutoCast && bIsTaskFinished)
+	{
+		EndAbility(CurrentSpecHandle, GetCurrentActorInfo(), GetCurrentActivationInfo(), true, false);
+	}
+}
+
+void UDrgGameplayAbility::OnCooldownEnded()
+{
+	if (bIsOnAutoCast)
+	{
+		GetAbilitySystemComponentFromActorInfo()->TryActivateAbility(CurrentSpecHandle);
+		bIsOnAutoCast = false;
+	}
+	else
+	{
+		UE_LOG(LogTemp, Error, TEXT("UDrgGameplayAbility: OnCooldownEnded 함수 논리 오류"));
+	}
+
+	EndAbilityAutoCheck();
+}

--- a/Source/Drg/AbilitySystem/Abilities/DrgGameplayAbility.h
+++ b/Source/Drg/AbilitySystem/Abilities/DrgGameplayAbility.h
@@ -13,5 +13,32 @@ UCLASS()
 class DRG_API UDrgGameplayAbility : public UGameplayAbility
 {
 	GENERATED_BODY()
-	
+
+public:
+	virtual void ActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo,
+	                             const FGameplayAbilityActivationInfo ActivationInfo,
+	                             const FGameplayEventData* TriggerEventData) override;
+
+	// 자동 시전 관련 체크 해주고 어빌리티 종료해주는 함수 
+	UFUNCTION(BlueprintCallable, Category = "Drg|Ability")
+	void EndTaskAutoCheck();
+
+	// 자동시전 활성화
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Drg|Ability")
+	bool bIsOnAutoCast = false;
+
+	//기본 쿨타임(공격속도 나누기로 적용됨)
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Drg|Ability", meta = (UIMin = "0.01", ClampMin = "0.01"))
+	float BaseCooldown = 1.0f;
+
+protected:
+	void StartCooldown();
+
+	void EndAbilityAutoCheck();
+
+	UFUNCTION()
+	void OnCooldownEnded();
+
+	// Task 사용 완료 (블루프린트)
+	bool bIsTaskFinished = false;
 };


### PR DESCRIPTION
### 변경 상세 내용

- 게임플레이 어빌리티에 쿨다운 메커니즘을 통합했으며, 공격 속도에 따라 쿨다운이 동적으로 조절되는 기능을 포함합니다.
- `ActivateAbility` 내에서 쿨다운 로직을 개시하는 `StartCooldown` 함수를 구현했습니다.
- 쿨다운이 완료되면 어빌리티가 자동으로 재사용되는 자동 시전 기능(`bIsOnAutoCast`)을 추가했습니다.
- 어빌리티 태스크의 상태에 따라 어빌리티 종료를 처리하는 함수(`EndTaskAutoCheck`, `EndAbilityAutoCheck`)를 추가했습니다.
- 쿨다운 시스템에 필요한 신규 게임플레이 태그(`Cooldown.Ability.Attack`, `Data.Cooldown.Duration`)를 정의하고 설정했습니다.
- 블루프린트에서의 확장성을 높이기 위해 관련 변수와 함수를 노출하고 기능을 보강했습니다.

### 관련 이슈

해당 없음

### 체크리스트

- [ ] 새로운 기능에 대한 테스트 추가/업데이트
- [ ] (해당하는 경우) 문서 업데이트
- [ ] (존재하는 경우) 관련 이슈 연결